### PR TITLE
ssh.1 Fix -i (mention .pub files if key in agent)

### DIFF
--- a/ssh.1
+++ b/ssh.1
@@ -297,6 +297,12 @@ It is possible to have multiple
 .Fl i
 options (and multiple identities specified in
 configuration files).
+If the private key is in
+.Xr ssh-agent 1
+rather than in a local file, specify the corresponding public key
+file instead, which must be present locally, to
+.Nm
+load the private key from the agent.
 If no certificates have been explicitly specified by the
 .Cm CertificateFile
 directive,


### PR DESCRIPTION
The -i option section in ssh.1 is incomplete. It states that the -i option argument is the private key file. This is one of two possibilities. If the private key only exists in ssh-agent, and not locally on disk, then the -i option argument needs to be the corresponding public key file instead. The reader is given no clue that this is a possibility. This commit adds a short sentence to make this clear.